### PR TITLE
BUGFIX - Remove AWS provider requirement, it is optional

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,3 +1,3 @@
 version: "1"
-module_version: 1.0.0
+module_version: 1.0.1
 runner_image: spacelift/runner:latest

--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
 | <a name="requirement_spacelift"></a> [spacelift](#requirement\_spacelift) | ~> 0.1.11 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 | <a name="provider_spacelift"></a> [spacelift](#provider\_spacelift) | ~> 0.1.11 |
 
 ## Modules

--- a/providers.tf
+++ b/providers.tf
@@ -4,9 +4,5 @@ terraform {
       source  = "spacelift-io/spacelift"
       version = "~> 0.1.11"
     }
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.0"
-    }
   }
 }


### PR DESCRIPTION
# What's in this PR
* Removes AWS provider as a requirement. This was an issue if you wanted to disable the AWS IAM Role creation and integration altogether, the AWS provider was still required. Doing this should resolve this issue.